### PR TITLE
Fix missing s in "utcsecondsmilliseconds"

### DIFF
--- a/api/ops.js
+++ b/api/ops.js
@@ -85,5 +85,5 @@ export const timeUnitOps = {
   utcHM: ['utchoursminutes'],
   utcHMS: ['utchoursminutesseconds'],
   utcMS: ['utcminutesseconds'],
-  utcSMS: ['utcsecondsmillisecond']
+  utcSMS: ['utcsecondsmilliseconds']
 };


### PR DESCRIPTION
FYI, I caught this error with TS as I copy this object and put it in vega-lite-to-api.  :p 

