### PR TITLE
Link into Vega-Lite docs for Vega-Lite configuration object

### DIFF
--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -117,7 +117,7 @@ __Note__:
 <a id="config" href="#config">#</a>
 <em>data</em>.<b>config</b>(<em>value</em>)
 
-Vega-Lite configuration object.  This property can only be defined at the top-level of a specification.
+[Vega-Lite configuration object](https://vega.github.io/vega-lite/docs/config.html).  This property can only be defined at the top-level of a specification.
 
 <a id="data" href="#data">#</a>
 <em>data</em>.<b>data</b>(<em>data</em>)

--- a/docs/api/hconcat.md
+++ b/docs/api/hconcat.md
@@ -64,7 +64,7 @@ __Default value:__ `false`
 <a id="config" href="#config">#</a>
 <em>hconcat</em>.<b>config</b>(<em>value</em>)
 
-Vega-Lite configuration object.  This property can only be defined at the top-level of a specification.
+[Vega-Lite configuration object](https://vega.github.io/vega-lite/docs/config.html).  This property can only be defined at the top-level of a specification.
 
 <a id="data" href="#data">#</a>
 <em>hconcat</em>.<b>data</b>(<em>data</em>)

--- a/docs/api/layer.md
+++ b/docs/api/layer.md
@@ -50,7 +50,7 @@ __Default value:__ none (transparent)
 <a id="config" href="#config">#</a>
 <em>layer</em>.<b>config</b>(<em>value</em>)
 
-Vega-Lite configuration object.  This property can only be defined at the top-level of a specification.
+[Vega-Lite configuration object](https://vega.github.io/vega-lite/docs/config.html).  This property can only be defined at the top-level of a specification.
 
 <a id="data" href="#data">#</a>
 <em>layer</em>.<b>data</b>(<em>data</em>)

--- a/docs/api/mark.md
+++ b/docs/api/mark.md
@@ -125,7 +125,7 @@ __Note__:
 <a id="config" href="#config">#</a>
 <em>mark</em>.<b>config</b>(<em>value</em>)
 
-Vega-Lite configuration object.  This property can only be defined at the top-level of a specification.
+[Vega-Lite configuration object](https://vega.github.io/vega-lite/docs/config.html).  This property can only be defined at the top-level of a specification.
 
 <a id="data" href="#data">#</a>
 <em>mark</em>.<b>data</b>(<em>data</em>)

--- a/docs/api/vconcat.md
+++ b/docs/api/vconcat.md
@@ -64,7 +64,7 @@ __Default value:__ `false`
 <a id="config" href="#config">#</a>
 <em>vconcat</em>.<b>config</b>(<em>value</em>)
 
-Vega-Lite configuration object.  This property can only be defined at the top-level of a specification.
+[Vega-Lite configuration object](https://vega.github.io/vega-lite/docs/config.html).  This property can only be defined at the top-level of a specification.
 
 <a id="data" href="#data">#</a>
 <em>vconcat</em>.<b>data</b>(<em>data</em>)


### PR DESCRIPTION
While perusing the docs, I found myself googling for "Vega-Lite configuration object", so thought I'd interlink the docs like this.