### PR TITLE
Generate ES class definitions.

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1,5 +1,5 @@
 import {enums, props, types} from './generate/schema';
-import {capitalize} from './generate/util';
+import {capitalize, reduce} from './generate/util';
 import schema from 'vega-lite/build/vega-lite-schema';
 import {aggregateOps, timeUnitOps, windowOps} from './ops';
 import {
@@ -14,39 +14,35 @@ const markTypes = enums(schema, {$ref: '#/definitions/AnyMark'});
 const dataFormats = types(schema, {$ref: '#/definitions/DataFormat'});
 
 function apiOps(ops, method, ...params) {
-  return Object.keys(ops)
-    .reduce((api, o) => (api[o] = method(...ops[o], ...params), api), {});
+  return reduce(ops, v => method(...ops[v], ...params));
 }
 
 function formats() {
-  return dataFormats
-    .reduce((api, f) => (api[`${f}Format`] = format(f), api), {});
+  return reduce(dataFormats, v => format(v), k => `${k}Format`);
 }
 
 function sources() {
-  return dataFormats
-    .reduce((api, f) => (api[`${f}`] = sourceFormat(f), api), {});
+  return reduce(dataFormats, v => sourceFormat(v));
 }
 
 function generators() {
   const types = props(schema, {$ref: '#/definitions/Generator'});
-  return Object.keys(types).filter(t => t !== 'name')
-    .reduce((api, g) => (api[g] = generator(g), api), {});
+  const items = Object.keys(types).filter(t => t !== 'name');
+  return reduce(items, v => generator(v));
 }
 
 function marks() {
-  return markTypes
-    .reduce((api, m) => (api[`mark${capitalize(m)}`] = mark(m), api), {});
+  return reduce(markTypes, v => mark(v), k => `mark${capitalize(k)}`);
 }
 
 function channels() {
-  return Object.keys(props(schema, {$ref: '#/definitions/FacetedEncoding'}))
-    .reduce((api, c) => (api[c] = channel(c), api), {});
+  const items = props(schema, {$ref: '#/definitions/FacetedEncoding'});
+  return reduce(items, v => channel(v));
 }
 
 function selections() {
-  return types(schema, {$ref: '#/definitions/SelectionDef'})
-    .reduce((api, t) => (api[`select${capitalize(t)}`] = selection(t), api), {});
+  const items = types(schema, {$ref: '#/definitions/SelectionDef'});
+  return reduce(items, v => selection(v), k => `select${capitalize(k)}`);
 }
 
 export const api = {

--- a/api/generate/schema.js
+++ b/api/generate/schema.js
@@ -51,12 +51,13 @@ export function types(schema, type) {
 
 export function isArrayType(schema) {
   if (hasArrayType(schema)) {
-    return true;
+    return 1;
   } else if (schema = (schema.anyOf || schema.oneOf)) {
-    // if there are two matching types (one scalar, one array)
-    return schema.length === 2 && schema.findIndex(hasArrayType) > -1;
+    let count = 0;
+    schema.forEach(s => { if (hasArrayType(s)) ++count });
+    return count === schema.length ? 1 : count ? 2 : 0;
   } else {
-    return false;
+    return 0;
   }
 }
 

--- a/api/generate/util.js
+++ b/api/generate/util.js
@@ -18,6 +18,18 @@ export function hasOwnProperty(obj, property) {
   return Object.prototype.hasOwnProperty.call(obj, property);
 }
 
+export function reduce(input, value, key) {
+  const items = Array.isArray(input)
+    ? input
+    : Object.keys(input);
+
+  return items.reduce((api, item) => {
+    const k = key ? key(item) : item;
+    api[k] = value(item);
+    return api;
+  }, {});
+}
+
 export function stringValue(_) {
   return Array.isArray(_) ? '[' + _.map(stringValue) + ']'
     : isObject(_) || isString(_) ?

--- a/api/generate/util.js
+++ b/api/generate/util.js
@@ -56,7 +56,7 @@ export function emitter(defaultFile) {
   };
 
   emit.outdent = () => {
-    prefix = prefix.slice(-2);
+    prefix = prefix.slice(0, prefix.length - 2);
     return emit;
   };
 
@@ -87,7 +87,10 @@ export function article(_) {
 }
 
 export function capitalize(_) {
-  return _[0].toUpperCase() + _.slice(1);
+  let i = 0;
+  const p = _[i] === '_' ? (++i, '_') : '';
+  const c = _[i];
+  return p + c.toUpperCase() + _.slice(++i);
 }
 
 export function uppercase(_) {

--- a/api/types.js
+++ b/api/types.js
@@ -223,7 +223,7 @@ export function channel(type) {
       fieldO: {arg: ['field'], set: {type: O}, desc: 'Encode the field as an ordinal data type.'},
       fieldQ: {arg: ['field'], set: {type: Q}, desc: 'Encode the field as a quantitative data type.'},
       fieldT: {arg: ['field'], set: {type: T}, desc: 'Encode the field as a temporal data type.'},
-      if: {arg: ['+++condition'], flag: 0, desc: 'Perform a conditional encoding. If the provided condition (first argument) evaluates to true, apply the provided encoding (second argument).'},
+      if: {arg: ['+++condition'], flag: 0, nest: ['test'], desc: 'Perform a conditional encoding. If the provided condition (first argument) evaluates to true, apply the provided encoding (second argument).'},
       ...channelAggregate,
       ...channelTimeUnit
     }

--- a/api/types.js
+++ b/api/types.js
@@ -1,5 +1,5 @@
 import {aggregateOps, timeUnitOps} from './ops';
-import {article, capitalize, code, link, uppercase} from './generate/util';
+import {article, capitalize, code, link, reduce, uppercase} from './generate/util';
 
 const N = 'nominal';
 const O = 'ordinal';
@@ -73,10 +73,7 @@ export function groupby() {
     desc: desc.groupby,
     doc:  'Data Transformations',
     arg:  ['...groupby'],
-    pass: transforms.reduce(
-      (obj, name) => (obj[name] = spec(name), obj),
-      {}
-    )
+    pass: reduce(transforms, v => spec(v))
   };
 }
 
@@ -436,10 +433,10 @@ const callSpec = {
 };
 
 export function unit(types) {
-  const extMark = types.reduce((o, m) => {
-    o[`mark${capitalize(m)}`] = {arg: [':::mark'], pre: [{type: m}]};
-    return o;
-  }, {});
+  const extMark = reduce(types,
+    v => ({arg: [':::mark'], pre: [{type: v}]}),
+    k => `mark${capitalize(k)}`
+  );
 
   return {
     desc: `Create a new mark of unspecified type.`,

--- a/static/__util__.js
+++ b/static/__util__.js
@@ -5,18 +5,8 @@ export function id(prefix) {
   return (prefix || '') + (++id_counter);
 }
 
-const prototype = {
-  toJSON: function() { return toJSON(this); }
-};
-
-export function proto(ctr) {
-  if (ctr) {
-    var p = (ctr.prototype = Object.create(prototype));
-    p.constructor = ctr;
-    return p;
-  } else {
-    return prototype;
-  }
+export class BaseObject {
+  toJSON() { return toJSON(this); }
 }
 
 export function assign(target, ...sources) {

--- a/test/selection-test.js
+++ b/test/selection-test.js
@@ -22,6 +22,17 @@ function refSpec(name) {
   return {selection: name};
 }
 
+function encSpec(test) {
+  return {
+    condition: {test, value: 1},
+    value: 0
+  };
+}
+
+function filtSpec(test) {
+  return {filter: test};
+}
+
 tape('Selection types are supported', function(t) {
   const names = ['single', 'multi', 'interval'];
   const single = vl.selectSingle(names[0]);
@@ -35,6 +46,32 @@ tape('Selection types are supported', function(t) {
   equalSpec(t, single, refSpec(names[0]));
   equalSpec(t, multi, refSpec(names[1]));
   equalSpec(t, interval, refSpec(names[2]));
+
+  t.end();
+});
+
+tape('Composite selection references are supported', function(t) {
+  const selA = vl.selectSingle('a');
+  const selB = vl.selectSingle('b');
+  const selC = vl.or(selA, selB);
+
+  const testA = refSpec('a');
+  const testB = refSpec('b');
+  const testC = {or: [testA, testB]};
+
+  const encA = vl.opacity().if(selA, vl.value(1)).value(0);
+  const encB = vl.opacity().if(selB, vl.value(1)).value(0);
+  const encC = vl.opacity().if(selC, vl.value(1)).value(0);
+  equalSpec(t, encA, encSpec(testA));
+  equalSpec(t, encB, encSpec(testB));
+  equalSpec(t, encC, encSpec(testC));
+
+  const filtA = vl.filter(selA);
+  const filtB = vl.filter(selB);
+  const filtC = vl.filter(selC);
+  equalSpec(t, filtA, filtSpec(testA));
+  equalSpec(t, filtB, filtSpec(testB));
+  equalSpec(t, filtC, filtSpec(testC));
 
   t.end();
 });

--- a/test/specs/query-widgets-test.js
+++ b/test/specs/query-widgets-test.js
@@ -58,7 +58,7 @@ var spec = {
         "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
         "color": {
           "value": "grey",
-          "condition": {"selection": "CylYr", "field": "Origin", "type": "nominal"}
+          "condition": {"test": {"selection": "CylYr"}, "field": "Origin", "type": "nominal"}
         }
       }
     },

--- a/test/specs/weather-selection-test.js
+++ b/test/specs/weather-selection-test.js
@@ -51,7 +51,7 @@ var spec = {
         "color": {
           "value": "lightgray",
           "condition": {
-            "selection": "sel1",
+            "test": {"selection": "sel1"},
             "field": "weather",
             "type": "nominal",
             "scale": {
@@ -91,7 +91,7 @@ var spec = {
         "color": {
           "value": "lightgray",
           "condition": {
-            "selection": "sel2",
+            "test": {"selection": "sel2"},
             "field": "weather",
             "type": "nominal",
             "scale": {

--- a/test/transform-test.js
+++ b/test/transform-test.js
@@ -1,0 +1,30 @@
+const tape = require('tape'),
+      vl = require('../');
+
+function equalSpec(t, api, spec) {
+  t.equal(JSON.stringify(api.toJSON()), JSON.stringify(spec));
+}
+
+tape('Lookup transform is supported', function(t) {
+  const data = vl.data('foo.csv');
+
+  const tran1 = vl.lookup('id').from(data).as('bar');
+  const spec1 = {
+    lookup: 'id',
+    from: {data: {url: 'foo.csv'}},
+    as: 'bar'
+  };
+  equalSpec(t, tran1, spec1);
+
+  const tran2a = vl.lookup('id').from(data).as(['bar', 'baz']);
+  const tran2b = vl.lookup('id').from(data).as('bar', 'baz');
+  const spec2 = {
+    lookup: 'id',
+    from: {data: {url: 'foo.csv'}},
+    as: ['bar', 'baz']
+  };
+  equalSpec(t, tran2a, spec2);
+  equalSpec(t, tran2b, spec2);
+
+  t.end();
+});


### PR DESCRIPTION
- Use `class` and `super` functionality, rather than directly working with `prototype` objects.
- Use `test` predicates when generating conditional encodings, via a `nest` attribute to API generator.
- Support union typed properties with both singular and array options.