### PR TITLE
Support selection references with additional fields.

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -5,7 +5,7 @@ import {aggregateOps, timeUnitOps, windowOps} from './ops';
 import {
   transform, groupby, aggregateOp, timeUnitOp, windowOp,
   field, fieldType, not, logical, repeat, value,
-  selection, binding, projection, encoding, channel,
+  selection, selref, binding, projection, encoding, channel,
   source, sourceFormat, generator, format, lookupData, data,
   unit, mark, layer, spec
 } from './types';
@@ -101,6 +101,7 @@ export const api = {
 
   // selections
   ...selections(),
+  _selref: selref(),
 
   // bindings
   checkbox:  binding('BindCheckbox', 'checkbox'),

--- a/api/generate/method.js
+++ b/api/generate/method.js
@@ -390,15 +390,21 @@ function generateAccretiveArrayProperty(emit, method, opt) {
 
 function generatePass(emit, method, opt) {
   emit.import(opt.call, opt.from || opt.call);
-  if (!opt.self) emit.import('assign');
+  if (!opt.self && !opt.init) emit.import('assign');
 
   emit(`${method}(...values) {`);
   if (opt.args) emit(`  values = values.slice(0, ${opt.args});`);
   if (opt.prop) {
-    emit(`  let obj = ${opt.call}();`);
-    opt.self
-      ? emit(`  obj = obj.${opt.self}(this);`)
-      : emit(`  obj = assign(obj, this);`);
+    if (opt.init) {
+      // this pulls an internal property as a constructor arg
+      // this could be revised to use / check the underscore prefix
+      emit(`  let obj = ${opt.call}(this["${opt.init}"]);`);
+    } else {
+      emit(`  let obj = ${opt.call}();`);
+      opt.self
+        ? emit(`  obj = obj.${opt.self}(this);`)
+        : emit(`  obj = assign(obj, this);`);
+    }
     emit(`  return obj.${opt.prop}(...values);`);
   } else {
     emit(`  const obj = ${opt.call}(...values);`);

--- a/api/types.js
+++ b/api/types.js
@@ -174,7 +174,43 @@ export function selection(type) {
     key: [
       {selection: '_sel'},
       '_sel'
-    ]
+    ],
+    pass: {
+      key: {
+        call: '_selref', init: '_sel', prop: 'key',
+        desc: 'Returns a selection reference including a key in data to lookup, when a selection is used within a lookup transform.'
+      },
+      field: {
+        call: '_selref', init: '_sel', prop: 'field',
+        desc: 'Returns a selection reference including a field name to extract selected values for, when a selection is projected over multiple fields or encodings.'
+      },
+      encoding:  {
+        call: '_selref', init: '_sel', prop: 'encoding',
+        desc: 'Returns a selection reference including an encoding channel to extract selected values for, when a selection is projected over multiple fields or encodings.'
+      }
+    }
+  };
+}
+
+export function selref() {
+  return {
+    desc: `Create a new selection reference.`,
+    doc:  'Selections',
+    arg:  ['selection'],
+    ext:  {
+      key: {
+        arg: ['key'],
+        desc: 'Key in data to lookup, when a selection is used within a lookup transform.'
+      },
+      field: {
+        arg: ['field'],
+        desc: 'A field name to extract selected values for, when a selection is projected over multiple fields or encodings.'
+      },
+      encoding:  {
+        arg: ['encoding'],
+        desc: 'An encoding channel to extract selected values for, when a selection is projected over multiple fields or encodings.'
+      }
+    }
   };
 }
 

--- a/docs/api/selectInterval.md
+++ b/docs/api/selectInterval.md
@@ -7,9 +7,12 @@ Define a new <code>interval</code> selection.
 * <a href="#bind">bind</a>
 * <a href="#clear">clear</a>
 * <a href="#empty">empty</a>
+* <a href="#encoding">encoding</a>
 * <a href="#encodings">encodings</a>
+* <a href="#field">field</a>
 * <a href="#fields">fields</a>
 * <a href="#init">init</a>
+* <a href="#key">key</a>
 * <a href="#mark">mark</a>
 * <a href="#on">on</a>
 * <a href="#resolve">resolve</a>
@@ -44,6 +47,11 @@ __See also:__ [`clear`](https://vega.github.io/vega-lite/docs/clear.html) docume
 By default, `all` data values are considered to lie within an empty selection.
 When set to `none`, empty selections contain no data values.
 
+<a id="encoding" href="#encoding">#</a>
+<em>selectInterval</em>.<b>encoding</b>(<em>...values</em>)
+
+Returns a selection reference including an encoding channel to extract selected values for, when a selection is projected over multiple fields or encodings.
+
 <a id="encodings" href="#encodings">#</a>
 <em>selectInterval</em>.<b>encodings</b>(<em>...value</em>)
 
@@ -51,6 +59,11 @@ An array of encoding channels. The corresponding data field values
 must match for a data tuple to fall within the selection.
 
 __See also:__ [`encodings`](https://vega.github.io/vega-lite/docs/project.html) documentation.
+
+<a id="field" href="#field">#</a>
+<em>selectInterval</em>.<b>field</b>(<em>...values</em>)
+
+Returns a selection reference including a field name to extract selected values for, when a selection is projected over multiple fields or encodings.
 
 <a id="fields" href="#fields">#</a>
 <em>selectInterval</em>.<b>fields</b>(<em>...value</em>)
@@ -67,6 +80,11 @@ Initialize the selection with a mapping between [projected channels or field nam
 initial values.
 
 __See also:__ [`init`](https://vega.github.io/vega-lite/docs/init.html) documentation.
+
+<a id="key" href="#key">#</a>
+<em>selectInterval</em>.<b>key</b>(<em>...values</em>)
+
+Returns a selection reference including a key in data to lookup, when a selection is used within a lookup transform.
 
 <a id="mark" href="#mark">#</a>
 <em>selectInterval</em>.<b>mark</b>(<em>value</em>)

--- a/docs/api/selectMulti.md
+++ b/docs/api/selectMulti.md
@@ -7,9 +7,12 @@ Define a new <code>multi</code> selection.
 * <a href="#bind">bind</a>
 * <a href="#clear">clear</a>
 * <a href="#empty">empty</a>
+* <a href="#encoding">encoding</a>
 * <a href="#encodings">encodings</a>
+* <a href="#field">field</a>
 * <a href="#fields">fields</a>
 * <a href="#init">init</a>
+* <a href="#key">key</a>
 * <a href="#nearest">nearest</a>
 * <a href="#on">on</a>
 * <a href="#resolve">resolve</a>
@@ -42,6 +45,11 @@ __See also:__ [`clear`](https://vega.github.io/vega-lite/docs/clear.html) docume
 By default, `all` data values are considered to lie within an empty selection.
 When set to `none`, empty selections contain no data values.
 
+<a id="encoding" href="#encoding">#</a>
+<em>selectMulti</em>.<b>encoding</b>(<em>...values</em>)
+
+Returns a selection reference including an encoding channel to extract selected values for, when a selection is projected over multiple fields or encodings.
+
 <a id="encodings" href="#encodings">#</a>
 <em>selectMulti</em>.<b>encodings</b>(<em>...value</em>)
 
@@ -49,6 +57,11 @@ An array of encoding channels. The corresponding data field values
 must match for a data tuple to fall within the selection.
 
 __See also:__ [`encodings`](https://vega.github.io/vega-lite/docs/project.html) documentation.
+
+<a id="field" href="#field">#</a>
+<em>selectMulti</em>.<b>field</b>(<em>...values</em>)
+
+Returns a selection reference including a field name to extract selected values for, when a selection is projected over multiple fields or encodings.
 
 <a id="fields" href="#fields">#</a>
 <em>selectMulti</em>.<b>fields</b>(<em>...value</em>)
@@ -65,6 +78,11 @@ Initialize the selection with a mapping between [projected channels or field nam
 value (or array of values).
 
 __See also:__ [`init`](https://vega.github.io/vega-lite/docs/init.html) documentation.
+
+<a id="key" href="#key">#</a>
+<em>selectMulti</em>.<b>key</b>(<em>...values</em>)
+
+Returns a selection reference including a key in data to lookup, when a selection is used within a lookup transform.
 
 <a id="nearest" href="#nearest">#</a>
 <em>selectMulti</em>.<b>nearest</b>(<em>value</em>)

--- a/docs/api/selectSingle.md
+++ b/docs/api/selectSingle.md
@@ -7,9 +7,12 @@ Define a new <code>single</code> selection.
 * <a href="#bind">bind</a>
 * <a href="#clear">clear</a>
 * <a href="#empty">empty</a>
+* <a href="#encoding">encoding</a>
 * <a href="#encodings">encodings</a>
+* <a href="#field">field</a>
 * <a href="#fields">fields</a>
 * <a href="#init">init</a>
+* <a href="#key">key</a>
 * <a href="#nearest">nearest</a>
 * <a href="#on">on</a>
 * <a href="#resolve">resolve</a>
@@ -47,6 +50,11 @@ __See also:__ [`clear`](https://vega.github.io/vega-lite/docs/clear.html) docume
 By default, `all` data values are considered to lie within an empty selection.
 When set to `none`, empty selections contain no data values.
 
+<a id="encoding" href="#encoding">#</a>
+<em>selectSingle</em>.<b>encoding</b>(<em>...values</em>)
+
+Returns a selection reference including an encoding channel to extract selected values for, when a selection is projected over multiple fields or encodings.
+
 <a id="encodings" href="#encodings">#</a>
 <em>selectSingle</em>.<b>encodings</b>(<em>...value</em>)
 
@@ -54,6 +62,11 @@ An array of encoding channels. The corresponding data field values
 must match for a data tuple to fall within the selection.
 
 __See also:__ [`encodings`](https://vega.github.io/vega-lite/docs/project.html) documentation.
+
+<a id="field" href="#field">#</a>
+<em>selectSingle</em>.<b>field</b>(<em>...values</em>)
+
+Returns a selection reference including a field name to extract selected values for, when a selection is projected over multiple fields or encodings.
 
 <a id="fields" href="#fields">#</a>
 <em>selectSingle</em>.<b>fields</b>(<em>...value</em>)
@@ -69,6 +82,11 @@ __See also:__ [`fields`](https://vega.github.io/vega-lite/docs/project.html) doc
 Initialize the selection with a mapping between [projected channels or field names](https://vega.github.io/vega-lite/docs/project.html) and initial values.
 
 __See also:__ [`init`](https://vega.github.io/vega-lite/docs/init.html) documentation.
+
+<a id="key" href="#key">#</a>
+<em>selectSingle</em>.<b>key</b>(<em>...values</em>)
+
+Returns a selection reference including a key in data to lookup, when a selection is used within a lookup transform.
 
 <a id="nearest" href="#nearest">#</a>
 <em>selectSingle</em>.<b>nearest</b>(<em>value</em>)

--- a/test/selection-test.js
+++ b/test/selection-test.js
@@ -18,8 +18,8 @@ function markSpec(name) {
   };
 }
 
-function refSpec(name) {
-  return {selection: name};
+function refSpec(name, opt) {
+  return {selection: name, ...opt};
 }
 
 function encSpec(test) {
@@ -72,6 +72,30 @@ tape('Composite selection references are supported', function(t) {
   equalSpec(t, filtA, filtSpec(testA));
   equalSpec(t, filtB, filtSpec(testB));
   equalSpec(t, filtC, filtSpec(testC));
+
+  t.end();
+});
+
+tape('Selections can produce references', function(t) {
+  const names = ['single', 'multi', 'interval'];
+  const single = vl.selectSingle(names[0]);
+  const multi = vl.selectMulti(names[1]);
+  const interval = vl.selectInterval(names[2]);
+
+  const key = 'key';
+  equalSpec(t, single.key(key), refSpec(names[0], {key}));
+  equalSpec(t, multi.key(key), refSpec(names[1], {key}));
+  equalSpec(t, interval.key(key), refSpec(names[2], {key}));
+
+  const field = 'field';
+  equalSpec(t, single.field(field), refSpec(names[0], {field}));
+  equalSpec(t, multi.field(field), refSpec(names[1], {field}));
+  equalSpec(t, interval.field(field), refSpec(names[2], {field}));
+
+  const encoding = 'enc';
+  equalSpec(t, single.encoding(encoding), refSpec(names[0], {encoding}));
+  equalSpec(t, multi.encoding(encoding), refSpec(names[1], {encoding}));
+  equalSpec(t, interval.encoding(encoding), refSpec(names[2], {encoding}));
 
   t.end();
 });


### PR DESCRIPTION
Update selection instances with `key`, `field`, and `encoding` methods that then return a selection reference with additional properties included.

Close #164.