### PR TITLE
Update toObject context, add raw input element binding

### DIFF
--- a/api/generate/method.js
+++ b/api/generate/method.js
@@ -242,13 +242,14 @@ function typeSwitch(emit, types, value) {
     let _ = types[key],
         set, val, check;
 
-    switch (key) {
-      case 'array':    check = 'isArray';    break;
-      case 'string':   check = 'isString';   break;
-      case 'number':   check = 'isNumber';   break;
-      case 'boolean':  check = 'isBoolean';  break;
-      case 'object':   check = 'isObject';   break;
-      case 'iterable': check = 'isIterable'; break;
+    switch (key.toLowerCase()) {
+      case 'array':       check = 'isArray'; break;
+      case 'string':      check = 'isString'; break;
+      case 'number':      check = 'isNumber'; break;
+      case 'boolean':     check = 'isBoolean'; break;
+      case 'object':      check = 'isObject'; break;
+      case 'eventtarget': check = 'isEventTarget'; break;
+      case 'iterable':    check = 'isIterable'; break;
     }
     emit.import(check);
 
@@ -315,10 +316,10 @@ function generateProperty(emit, method, opt) {
     emit(    `value = ${typeSwitch(emit, type, 'value')};`);
   }
 
-  // if a non-falsy flag is specified, map value now
+  // if a non-falsy flag is specified, annotate value with context
   if (flag) {
-    emit.import('objectify');
-    emit(    `value = objectify(value, ${flag});`);
+    emit.import('annotate');
+    emit(    `value = annotate(value, ${flag});`);
   }
 
   emit(    `set(obj, ${$(prop)}, value);`);

--- a/api/generate/util.js
+++ b/api/generate/util.js
@@ -91,7 +91,7 @@ export function emitter(defaultFile) {
 }
 
 export function article(_) {
-  return _ && _.match(/^[aeiou]/) ? 'an' : 'a';
+  return _ && _.match(/^[aeiou]/i) ? 'an' : 'a';
 }
 
 export function capitalize(_) {

--- a/api/types.js
+++ b/api/types.js
@@ -185,6 +185,16 @@ export function binding(def, input, args) {
   };
 }
 
+const extParam = {
+  bind: {
+    arg: ['bind'],
+    desc: 'Input element bindings for this parameter.\n\n__See:__ [`bind`](https://vega.github.io/vega-lite/docs/bind.html) documentation.',
+    type: [{
+      EventTarget: { key: 'element', raw: true }
+    }]
+  }
+};
+
 const passParam = {
   key: {
     call: '_selRef', init: 'name', prop: 'key',
@@ -214,6 +224,7 @@ export function param() {
       { key: { param: 'name' } },
       null
     ],
+    ext:  extParam,
     pass: passParam
   };
 }
@@ -230,8 +241,8 @@ export function selection(type) {
       { nest: { keys: ['name', 'bind', 'value', 'views'], rest: 'select' } }
     ],
     ext:  {
+      ...extParam,
       name:  {arg: ['name'], desc: 'A unique name for the selection parameter. Selection names should be valid JavaScript identifiers: they should contain only alphanumeric characters (or "$", or "_") and may not start with a digit. Reserved keywords that may not be used as parameter names are "datum", "event", "item", and "parent".'},
-      bind:  {arg: ['bind'], desc: 'Input element bindings for this selection. \n\n__See:__ [`bind`](https://vega.github.io/vega-lite/docs/bind.html) documentation.'},
       value: {arg: ['value'], desc: 'Initialize the selection with a mapping between [projected channels or field names](https://vega.github.io/vega-lite/docs/project.html) and initial values.'},
       views: {arg: ['views'], desc: 'By default, top-level selections are applied to every view in the visualization. If this property is specified, selections will only be applied to views with the given names.'}
     },
@@ -441,7 +452,7 @@ export function sourceFormat(type) {
     desc: `Define a data source for ${code(type)} format data.`,
     doc:  'Data',
     def:  `${capitalize(formatDefs[type] || type)}DataFormat`,
-    type: {object: {key: 'values'}, ...typeData[0]},
+    type: {Object: {key: 'values'}, ...typeData[0]},
     out:  {nest: {keys: ['url', 'values', 'name'], rest: 'format'}},
     set:  {type: type},
     ext:  {
@@ -470,8 +481,8 @@ export function lookupSelection() {
     arg:  ['param'],
     type: [
       {
-        object: {prop: 'name'},
-        string: {}
+        Object: {prop: 'name'},
+        String: {}
       }
     ]
   };
@@ -504,16 +515,16 @@ export function generator(type) {
 
 const typeData = [
   {
-    array:    {key: 'values', raw: true},
-    iterable: {key: 'values', raw: true},
-    string:   {key: 'url'}
+    Array:    {key: 'values', raw: true},
+    Iterable: {key: 'values', raw: true},
+    String:   {key: 'url'}
   }
 ];
 
 const typeRaw = [
   {
-    array:  {raw: true},
-    object: {raw: true}
+    Array:  {raw: true},
+    Object: {raw: true}
   }
 ];
 
@@ -532,7 +543,7 @@ const extLayer = {
 };
 
 const extUnit = {
-  mark:   {arg: [':::mark'], type: [{string: {key: 'type'}}], desc: 'Set the mark type and default visual properties.'},
+  mark:   {arg: [':::mark'], type: [{String: {key: 'type'}}], desc: 'Set the mark type and default visual properties.'},
   params: {arg: ['...params'], flag: 1, desc: 'An array of parameters that may be simple variables or more complex selections that map user input to data queries.'},
   ...extLayer
 };
@@ -560,7 +571,7 @@ export function unit(types) {
     doc:  'Chart Constructors',
     def:  'TopLevelUnitSpec',
     arg:  [':::mark'],
-    type: [{string: {key: 'type'}}],
+    type: [{String: {key: 'type'}}],
     ext:  {...extUnit, ...extMark},
     call: callSpec,
     pass: passMulti

--- a/docs/api/concat.md
+++ b/docs/api/concat.md
@@ -105,9 +105,9 @@ The input [data](data) specification.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>data.values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>data.values</code> property.
-- If the argument is a <code>string</code>, sets the <code>data.url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>data.values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>data.values</code> property.
+- If the argument is a <code>String</code>, sets the <code>data.url</code> property.
 - Otherwise, sets the <code>data</code> property.
 
 <a id="datasets" href="#datasets">#</a>

--- a/docs/api/csv.md
+++ b/docs/api/csv.md
@@ -4,10 +4,10 @@ Define a data source for <code>csv</code> format data.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>values</code> property.
-- If the argument is an <code>object</code>, sets the <code>values</code> property.
-- If the argument is a <code>string</code>, sets the <code>url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>values</code> property.
+- If the argument is an <code>Object</code>, sets the <code>values</code> property.
+- If the argument is a <code>String</code>, sets the <code>url</code> property.
 - Otherwise, sets the properties defined on the input argument(s), if provided.
 
 ## <code>csv</code> Method Overview

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -4,9 +4,9 @@ Create a new data reference for a chart or lookup.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>values</code> property.
-- If the argument is a <code>string</code>, sets the <code>url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>values</code> property.
+- If the argument is a <code>String</code>, sets the <code>url</code> property.
 - Otherwise, sets the properties defined on the input argument(s), if provided.
 
 ## <code>data</code> Method Overview
@@ -104,9 +104,9 @@ The input [data](data) specification.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>data.values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>data.values</code> property.
-- If the argument is a <code>string</code>, sets the <code>data.url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>data.values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>data.values</code> property.
+- If the argument is a <code>String</code>, sets the <code>data.url</code> property.
 - Otherwise, sets the <code>data</code> property.
 
 <a id="datasets" href="#datasets">#</a>
@@ -169,7 +169,7 @@ Set the mark type and default visual properties.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is a <code>string</code>, sets the <code>mark.type</code> property.
+- If the argument is a <code>String</code>, sets the <code>mark.type</code> property.
 - Otherwise, sets the <code>mark</code> property.
 
 <a id="mark" href="#mark">#</a>

--- a/docs/api/dsv.md
+++ b/docs/api/dsv.md
@@ -4,10 +4,10 @@ Define a data source for <code>dsv</code> format data.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>values</code> property.
-- If the argument is an <code>object</code>, sets the <code>values</code> property.
-- If the argument is a <code>string</code>, sets the <code>url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>values</code> property.
+- If the argument is an <code>Object</code>, sets the <code>values</code> property.
+- If the argument is a <code>String</code>, sets the <code>url</code> property.
 - Otherwise, sets the properties defined on the input argument(s), if provided.
 
 ## <code>dsv</code> Method Overview

--- a/docs/api/hconcat.md
+++ b/docs/api/hconcat.md
@@ -72,9 +72,9 @@ The input [data](data) specification.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>data.values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>data.values</code> property.
-- If the argument is a <code>string</code>, sets the <code>data.url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>data.values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>data.values</code> property.
+- If the argument is a <code>String</code>, sets the <code>data.url</code> property.
 - Otherwise, sets the <code>data</code> property.
 
 <a id="datasets" href="#datasets">#</a>

--- a/docs/api/json.md
+++ b/docs/api/json.md
@@ -4,10 +4,10 @@ Define a data source for <code>json</code> format data.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>values</code> property.
-- If the argument is an <code>object</code>, sets the <code>values</code> property.
-- If the argument is a <code>string</code>, sets the <code>url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>values</code> property.
+- If the argument is an <code>Object</code>, sets the <code>values</code> property.
+- If the argument is a <code>String</code>, sets the <code>url</code> property.
 - Otherwise, sets the properties defined on the input argument(s), if provided.
 
 ## <code>json</code> Method Overview

--- a/docs/api/layer.md
+++ b/docs/api/layer.md
@@ -58,9 +58,9 @@ The input [data](data) specification.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>data.values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>data.values</code> property.
-- If the argument is a <code>string</code>, sets the <code>data.url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>data.values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>data.values</code> property.
+- If the argument is a <code>String</code>, sets the <code>data.url</code> property.
 - Otherwise, sets the <code>data</code> property.
 
 <a id="datasets" href="#datasets">#</a>

--- a/docs/api/lookupData.md
+++ b/docs/api/lookupData.md
@@ -4,9 +4,9 @@ Specify a lookup on a secondary data source.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>values</code> property.
-- If the argument is a <code>string</code>, sets the <code>url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>values</code> property.
+- If the argument is a <code>String</code>, sets the <code>url</code> property.
 - Otherwise, sets the properties defined on the input argument(s), if provided.
 
 ## <code>lookupData</code> Method Overview

--- a/docs/api/mark.md
+++ b/docs/api/mark.md
@@ -4,7 +4,7 @@ Create a new mark of unspecified type.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is a <code>string</code>, sets the <code>type</code> property.
+- If the argument is a <code>String</code>, sets the <code>type</code> property.
 - Otherwise, sets the properties defined on the input argument(s), if provided.
 
 ## <code>mark</code> Method Overview
@@ -113,9 +113,9 @@ The input [data](data) specification.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>data.values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>data.values</code> property.
-- If the argument is a <code>string</code>, sets the <code>data.url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>data.values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>data.values</code> property.
+- If the argument is a <code>String</code>, sets the <code>data.url</code> property.
 - Otherwise, sets the <code>data</code> property.
 
 <a id="datasets" href="#datasets">#</a>
@@ -158,7 +158,7 @@ Set the mark type and default visual properties.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is a <code>string</code>, sets the <code>mark.type</code> property.
+- If the argument is a <code>String</code>, sets the <code>mark.type</code> property.
 - Otherwise, sets the <code>mark</code> property.
 
 <a id="markArc" href="#markArc">#</a>

--- a/docs/api/param.md
+++ b/docs/api/param.md
@@ -18,9 +18,16 @@ Define or reference a variable parameter.
 ## <code>param</code> API Reference
 
 <a id="bind" href="#bind">#</a>
-<em>param</em>.<b>bind</b>(<em>value</em>)
+<em>param</em>.<b>bind</b>(<em>bind</em>)
 
-Binds the parameter to an external input element such as a slider, selection list or radio button group.
+Input element bindings for this selection. 
+
+__See:__ [`bind`](https://vega.github.io/vega-lite/docs/bind.html) documentation.
+
+The behavior of this method depends on the argument type:
+
+- If the argument is an <code>EventTarget</code>, sets the <code>bind.element</code> property.
+- Otherwise, sets the <code>bind</code> property.
 
 <a id="empty" href="#empty">#</a>
 <em>param</em>.<b>empty</b>(<em>...values</em>)

--- a/docs/api/selectInterval.md
+++ b/docs/api/selectInterval.md
@@ -31,6 +31,11 @@ Input element bindings for this selection.
 
 __See:__ [`bind`](https://vega.github.io/vega-lite/docs/bind.html) documentation.
 
+The behavior of this method depends on the argument type:
+
+- If the argument is an <code>EventTarget</code>, sets the <code>bind.element</code> property.
+- Otherwise, sets the <code>bind</code> property.
+
 <a id="clear" href="#clear">#</a>
 <em>selectInterval</em>.<b>clear</b>(<em>value</em>)
 

--- a/docs/api/selectPoint.md
+++ b/docs/api/selectPoint.md
@@ -30,6 +30,11 @@ Input element bindings for this selection.
 
 __See:__ [`bind`](https://vega.github.io/vega-lite/docs/bind.html) documentation.
 
+The behavior of this method depends on the argument type:
+
+- If the argument is an <code>EventTarget</code>, sets the <code>bind.element</code> property.
+- Otherwise, sets the <code>bind</code> property.
+
 <a id="clear" href="#clear">#</a>
 <em>selectPoint</em>.<b>clear</b>(<em>value</em>)
 

--- a/docs/api/topojson.md
+++ b/docs/api/topojson.md
@@ -4,10 +4,10 @@ Define a data source for <code>topojson</code> format data.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>values</code> property.
-- If the argument is an <code>object</code>, sets the <code>values</code> property.
-- If the argument is a <code>string</code>, sets the <code>url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>values</code> property.
+- If the argument is an <code>Object</code>, sets the <code>values</code> property.
+- If the argument is a <code>String</code>, sets the <code>url</code> property.
 - Otherwise, sets the properties defined on the input argument(s), if provided.
 
 ## <code>topojson</code> Method Overview

--- a/docs/api/tsv.md
+++ b/docs/api/tsv.md
@@ -4,10 +4,10 @@ Define a data source for <code>tsv</code> format data.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>values</code> property.
-- If the argument is an <code>object</code>, sets the <code>values</code> property.
-- If the argument is a <code>string</code>, sets the <code>url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>values</code> property.
+- If the argument is an <code>Object</code>, sets the <code>values</code> property.
+- If the argument is a <code>String</code>, sets the <code>url</code> property.
 - Otherwise, sets the properties defined on the input argument(s), if provided.
 
 ## <code>tsv</code> Method Overview

--- a/docs/api/vconcat.md
+++ b/docs/api/vconcat.md
@@ -72,9 +72,9 @@ The input [data](data) specification.
 
 The behavior of this method depends on the argument type:
 
-- If the argument is an <code>array</code>, sets the <code>data.values</code> property.
-- If the argument is an <code>iterable</code>, sets the <code>data.values</code> property.
-- If the argument is a <code>string</code>, sets the <code>data.url</code> property.
+- If the argument is an <code>Array</code>, sets the <code>data.values</code> property.
+- If the argument is an <code>Iterable</code>, sets the <code>data.values</code> property.
+- If the argument is a <code>String</code>, sets the <code>data.url</code> property.
 - Otherwise, sets the <code>data</code> property.
 
 <a id="datasets" href="#datasets">#</a>


### PR DESCRIPTION
- Add support for raw `EventTarget`s for input element binding.
- Add `Context` symbol to parameterize toObject serialization.
- Remove immediate context-based serialization, use context and `MergeObject` instead.
- Update type switches to use capitalized type names.
