### PR TITLE
docs: Update link to Observable v5 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To produce Vega-Lite JSON like this:
 To get started with the Vega-Lite API, see these Observable notebooks:
 
 - [Introduction to Vega-Lite](https://observablehq.com/@uwdata/introduction-to-vega-lite)
-- [Vega-Lite API](https://observablehq.com/@vega/vega-lite-api)
+- [Vega-Lite API](https://observablehq.com/@vega/vega-lite-api-v5)
 - [Vega-Lite API Collection](https://observablehq.com/collection/@vega/vega-lite-api)
 
 ## Build Instructions


### PR DESCRIPTION
Updates the link in the docs to the v5 page. The current link goes to v4.